### PR TITLE
Explicitly annotate void return type

### DIFF
--- a/trailer.d.ts
+++ b/trailer.d.ts
@@ -12,4 +12,4 @@ export function listen(server: import("net").Server, tunnel?: NgrokTunnel): Ngro
  * Register a console.log callback for ngrok INFO logging.
  * Optionally set the logging level to one of ERROR, WARN, INFO, DEBUG, or TRACE.
  */
-export function consoleLog(level?: String);
+export function consoleLog(level?: String): void;


### PR DESCRIPTION
This fixes the following error under the `noImplicitAny` TypeScript compiler flag:

```
node_modules/@ngrok/ngrok/index.d.ts:567:17 - error TS7010: 'consoleLog', which lacks return-type annotation, implicitly has an 'any' return type.

567 export function consoleLog(level?: String);
                    ~~~~~~~~~~
```