### PR TITLE
Add ngrok.tunnels() and session.tunnels()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,13 @@ async-rustls = { version = "0.3.0" }
 async-trait = "0.1.59"
 bytes = "1.3.0"
 lazy_static = "1.4.0"
+# pin mio until all dependencies are also on windows-sys 0.48
+# https://github.com/microsoft/windows-rs/issues/2410#issuecomment-1490802715
+mio = { version = "=0.8.6" }
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.12.1", default-features = false, features = ["napi4", "tokio_rt"] }
 napi-derive = "2.12.1"
-ngrok = { version = "0.12.1" }
+ngrok = { version = "0.12.3" }
 parking_lot = "0.12.1"
 rustls-pemfile = "1.0.1"
 tokio = { version = "1.23.0", features = ["sync"] }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ npx degit github:ngrok/ngrok-nodejs/examples/express express && cd express && np
 
 
 ## Frameworks
+* [AWS App Runner](https://aws.amazon.com/apprunner/) - See the [ngrok SDK Serverless Example](https://github.com/ngrok/ngrok-sdk-serverless-example) repository
 * [Express](https://expressjs.com/) - [Quickstart Example](https://github.com/ngrok/ngrok-nodejs/blob/main/examples/express/ngrok-express-quickstart.js), [Configuration Example](https://github.com/ngrok/ngrok-nodejs/blob/main/examples/express/ngrok-express.js)
 * [Fastify](https://www.fastify.io/) - [Example](https://github.com/ngrok/ngrok-nodejs/blob/main/examples/fastify/ngrok-fastify.js)
 * [Hapi](https://hapi.dev/) - [Example](https://github.com/ngrok/ngrok-nodejs/blob/main/examples/hapi/ngrok-hapi.js)

--- a/__test__/online.spec.mjs
+++ b/__test__/online.spec.mjs
@@ -79,6 +79,11 @@ test("https tunnel", async (t) => {
   t.truthy(tunnel.url().startsWith("https://"), tunnel.url());
   t.is("http forwards to", tunnel.forwardsTo());
   t.is("http metadata", tunnel.metadata());
+  const tunnel_list = await session.tunnels();
+  t.is(1, tunnel_list.length)
+  t.is(tunnel.id(), tunnel_list[0].id());
+  t.is(tunnel.url(), tunnel_list[0].url());
+
 
   await forwardValidateShutdown(t, httpServer, tunnel, tunnel.url());
 });
@@ -348,6 +353,11 @@ test("tcp multipass", async (t) => {
   tunnel2.forwardTcp(httpServer.listenTo);
   tunnel3.forwardTcp(httpServer.listenTo);
   tunnel4.forwardTcp(httpServer.listenTo);
+
+  t.is(2, (await session1.tunnels()).length)
+  t.is(2, (await session2.tunnels()).length)
+  t.truthy((await ngrok.tunnels()).length >= 4)
+  t.is(tunnel3.url(), (await ngrok.getTunnel(tunnel3.id())).url())
 
   await validateHttpRequest(t, tunnel1.url());
   await validateHttpRequest(t, tunnel2.url());

--- a/index.d.ts
+++ b/index.d.ts
@@ -182,6 +182,10 @@ export function kill(): Promise<void>
 export function loggingCallback(callback?: (level: string, target: string, message: string) => void, level?: string): void
 /** Set the default auth token to use for any future sessions. */
 export function authtoken(authtoken: string): Promise<void>
+/** Retrieve a list of non-closed tunnels, in no particular order. */
+export function tunnels(): Promise<Array<NgrokTunnel>>
+/** Retrieve tunnel using the id */
+export function getTunnel(id: string): Promise<NgrokTunnel | null>
 /**
  * The builder for an ngrok session.
  *
@@ -346,6 +350,8 @@ export class NgrokSession {
   tlsEndpoint(): NgrokTlsTunnelBuilder
   /** Start building a labeled tunnel. */
   labeledTunnel(): NgrokLabeledTunnelBuilder
+  /** Retrieve a list of this session's non-closed tunnels, in no particular order. */
+  tunnels(): Promise<Array<NgrokTunnel>>
   /** Close a tunnel with the given ID. */
   closeTunnel(id: string): Promise<void>
   /** Close the ngrok session. */

--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { connect, disconnect, kill, loggingCallback, authtoken, NgrokSessionBuilder, NgrokSession, UpdateRequest, NgrokTunnel, NgrokHttpTunnelBuilder, NgrokTcpTunnelBuilder, NgrokTlsTunnelBuilder, NgrokLabeledTunnelBuilder } = nativeBinding
+const { connect, disconnect, kill, loggingCallback, authtoken, NgrokSessionBuilder, NgrokSession, UpdateRequest, NgrokTunnel, tunnels, getTunnel, NgrokHttpTunnelBuilder, NgrokTcpTunnelBuilder, NgrokTlsTunnelBuilder, NgrokLabeledTunnelBuilder } = nativeBinding
 
 module.exports.connect = connect
 module.exports.disconnect = disconnect
@@ -263,6 +263,8 @@ module.exports.NgrokSessionBuilder = NgrokSessionBuilder
 module.exports.NgrokSession = NgrokSession
 module.exports.UpdateRequest = UpdateRequest
 module.exports.NgrokTunnel = NgrokTunnel
+module.exports.tunnels = tunnels
+module.exports.getTunnel = getTunnel
 module.exports.NgrokHttpTunnelBuilder = NgrokHttpTunnelBuilder
 module.exports.NgrokTcpTunnelBuilder = NgrokTcpTunnelBuilder
 module.exports.NgrokTlsTunnelBuilder = NgrokTlsTunnelBuilder

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -146,7 +146,10 @@ async fn async_connect(s_builder: NgrokSessionBuilder, config: Config) -> Result
         _ => return Err(napi_err(format!("unhandled protocol {proto}"))),
     };
 
-    let url = tunnel::get_url(&id).await.unwrap_or(id.clone());
+    let url = tunnel::get_tunnel(id.clone())
+        .await
+        .and_then(|t| t.url())
+        .unwrap_or(id.clone());
 
     // move forwarding to another task
     if let Some(addr) = config.addr {


### PR DESCRIPTION
Adds `ngrok.tunnels()`, `session.tunnels()`, and `ngrok.getTunnel(id)`. This necessitated finishing the move of immutable tunnel metadata into `Storage` and building `NgrokTunnel`'s from that.

Also debugged windows build issue which resulted in pinning `mio` until all dependencies have `windows-sys` of `0.48.0`.