### PR TITLE
More elaborate unix socket placement, add ngrok.getTunnelByUrl(url)

### DIFF
--- a/__test__/online.spec.mjs
+++ b/__test__/online.spec.mjs
@@ -83,7 +83,7 @@ test("https tunnel", async (t) => {
   t.is(1, tunnel_list.length)
   t.is(tunnel.id(), tunnel_list[0].id());
   t.is(tunnel.url(), tunnel_list[0].url());
-
+  t.is(tunnel.id(), (await ngrok.getTunnelByUrl(tunnel.url())).id());
 
   await forwardValidateShutdown(t, httpServer, tunnel, tunnel.url());
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -186,6 +186,8 @@ export function authtoken(authtoken: string): Promise<void>
 export function tunnels(): Promise<Array<NgrokTunnel>>
 /** Retrieve tunnel using the id */
 export function getTunnel(id: string): Promise<NgrokTunnel | null>
+/** Retrieve tunnel using the url */
+export function getTunnelByUrl(url: string): Promise<NgrokTunnel | null>
 /**
  * The builder for an ngrok session.
  *

--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { connect, disconnect, kill, loggingCallback, authtoken, NgrokSessionBuilder, NgrokSession, UpdateRequest, NgrokTunnel, tunnels, getTunnel, NgrokHttpTunnelBuilder, NgrokTcpTunnelBuilder, NgrokTlsTunnelBuilder, NgrokLabeledTunnelBuilder } = nativeBinding
+const { connect, disconnect, kill, loggingCallback, authtoken, NgrokSessionBuilder, NgrokSession, UpdateRequest, NgrokTunnel, tunnels, getTunnel, getTunnelByUrl, NgrokHttpTunnelBuilder, NgrokTcpTunnelBuilder, NgrokTlsTunnelBuilder, NgrokLabeledTunnelBuilder } = nativeBinding
 
 module.exports.connect = connect
 module.exports.disconnect = disconnect
@@ -265,6 +265,7 @@ module.exports.UpdateRequest = UpdateRequest
 module.exports.NgrokTunnel = NgrokTunnel
 module.exports.tunnels = tunnels
 module.exports.getTunnel = getTunnel
+module.exports.getTunnelByUrl = getTunnelByUrl
 module.exports.NgrokHttpTunnelBuilder = NgrokHttpTunnelBuilder
 module.exports.NgrokTcpTunnelBuilder = NgrokTcpTunnelBuilder
 module.exports.NgrokTlsTunnelBuilder = NgrokTlsTunnelBuilder
@@ -276,6 +277,7 @@ module.exports.NgrokLabeledTunnelBuilder = NgrokLabeledTunnelBuilder
 const net = require("net");
 const fs = require("fs");
 const os = require("os");
+const path = require("path");
 
 // wrap listen with the bind code for passing to net.Server.listen()
 NgrokHttpTunnelBuilder.prototype._listen = NgrokHttpTunnelBuilder.prototype.listen;
@@ -388,26 +390,52 @@ async function ngrokLinkTcp(tunnel, server) {
   return socket;
 }
 
-async function ngrokLinkPipe(tunnel, server) {
+function generatePipeFilename(tunnel, server) {
   var proposed = "tun-" + tunnel.id() + ".sock";
+
+  // windows leaves little choice
   if (platform == "win32") {
-    proposed = "\\\\.\\pipe\\" + proposed;
+    return "\\\\.\\pipe\\" + proposed;
   }
-  var filename;
+
+  // try to make a directory in the current working directory
+  const dir = ".ngrok";
   try {
-    fs.accessSync(process.cwd(), fs.constants.W_OK);
-    filename = proposed;
+    fs.mkdirSync(dir);
   } catch (err) {
-    console.debug("Cannot write to: " + process.cwd());
-    // try tmp. allow any exception to propagate
-    fs.accessSync(os.tmpdir(), fs.constants.W_OK);
-    filename = os.tmpdir() + proposed;
+    // move on
+  }
+  try {
+    fs.accessSync(dir, fs.constants.W_OK);
+    return dir + path.sep + proposed;
+  } catch (err) {
+    // move on
   }
 
-  if (!filename) {
-    throw new Error("no writeable directory found");
+  // try the OS temp directory, being careful not to exceed the maximum path length for unix sockets
+  // https://linux.die.net/man/7/unix
+  // https://unix.stackexchange.com/a/367012
+  if (os.tmpdir().length < 90) {
+    try {
+      fs.accessSync(os.tmpdir(), fs.constants.W_OK);
+      filepath = os.tmpdir() + path.sep + proposed;
+      if (filepath.length > 100) {
+        // truncate
+        filepath = filepath.substring(0, 100);
+      }
+      return filepath;
+    } catch (err) {
+      // move on
+    }
   }
 
+  // fallback to current working directory. allow any exception to propagate
+  fs.accessSync(process.cwd(), fs.constants.W_OK);
+  return proposed;
+}
+
+async function ngrokLinkPipe(tunnel, server) {
+  var filename = generatePipeFilename(tunnel);
   // begin listening
   const socket = await asyncListen(server, { path: filename });
   // tighten permissions
@@ -459,6 +487,7 @@ function consoleLog(level) {
 // wrap connect with code to vectorize and split out functions
 const _connect = connect;
 async function ngrokConnect(config) {
+  if (config == undefined) config = 80;
   if (Number.isInteger(config) || typeof config === "string" || config instanceof String) {
     address = String(config);
     if (!address.includes(":")) {

--- a/src/session.rs
+++ b/src/session.rs
@@ -463,7 +463,7 @@ impl NgrokSession {
     #[napi]
     pub async fn tunnels(&self) -> Vec<NgrokTunnel> {
         let session_id = self.raw_session.lock().id();
-        list_tunnels(Some(session_id)).await
+        list_tunnels(Some(session_id), None).await
     }
 
     /// Close a tunnel with the given ID.


### PR DESCRIPTION
Builds a bit on the last PR, allowing a lookup by url since that's what users have after calling `connect`. Also tries to put a unix socket in an `.ngrok` directory first, then os.tmpdir, then current working directory, per feedback from product.