### PR TITLE
Added "files" to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.d.js"
+    "index.d.ts"
   ],
   "napi": {
     "name": "ngrok",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.9.0",
   "main": "index.js",
   "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "index.d.js"
+  ],
   "napi": {
     "name": "ngrok",
     "triples": {


### PR DESCRIPTION
Added the "files" key to `package.json` to make NPM deployments slimmer. Don't really need "docs" or "examples" or other dev files in the NPM package.

This will slim down the NPM package from 149 files, to 6 (LICENSE files, README, and package.json are default required).