### PR TITLE
Update package.json "repository" value

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
   },
   "packageManager": "yarn@3.3.1",
   "description": "The ngrok agent in library form, suitable for integrating directly into your NodeJS application.",
-  "repository": "https://github.com/ngrok/ngrok-nodejs"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ngrok/ngrok-nodejs.git"
+  }
 }


### PR DESCRIPTION
Per NPM's official documentation:

"The URL should be a publicly available (perhaps read-only) url that can be handed directly to a VCS program without any modification. It should not be a url to an html project page that you put in your browser. It's for computers."

https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository